### PR TITLE
Add meta tags in helmet and header and footer interfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ docs/_book/
 .tmp
 .idea
 npm-debug.log
+yarn-error.log
 .build/
 lib
 *.orig

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- Initial version of base AMP store.

--- a/manifest.json
+++ b/manifest.json
@@ -10,6 +10,9 @@
   "peerDependencies": {
     "vtex.store": "2.x"
   },
-  "dependencies": {},
+  "dependencies": {
+    "vtex.store-header": "2.x",
+    "vtex.store-footer": "2.x"
+  },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/react/AmpProvider.tsx
+++ b/react/AmpProvider.tsx
@@ -1,7 +1,54 @@
 import React from 'react'
+import { Helmet } from 'react-helmet'
+import { useRuntime } from 'vtex.render-runtime'
+
+const CONTENT_TYPE = 'text/html; charset=utf-8'
+const META_ROBOTS = 'index, follow'
+
+const joinKeywords = (keywords: string[]) => keywords && keywords.join(', ')
 
 const AmpProvider: React.FC = ({ children }) => {
-  return <React.Fragment>{children}</React.Fragment>
+  const {
+    getSettings,
+    culture: { country, locale, currency },
+    route: { title: pageTitle, metaTags },
+  } = useRuntime()
+
+  const storeSettings = getSettings('vtex.store')
+
+  const {
+    titleTag,
+    metaTagDescription,
+    metaTagKeywords,
+    metaTagRobots,
+    storeName,
+  } = storeSettings
+
+  const description = (metaTags && metaTags.description) || metaTagDescription
+  const keywords =
+    joinKeywords(metaTags && metaTags.keywords) || metaTagKeywords
+
+  const title = pageTitle || titleTag
+
+  return (
+    <React.Fragment>
+      <Helmet
+        title={title}
+        meta={[
+          { name: 'description', content: description },
+          { name: 'keywords', content: keywords },
+          { name: 'copyright', content: storeName },
+          { name: 'author', content: storeName },
+          { name: 'country', content: country },
+          { name: 'language', content: locale },
+          { name: 'currency', content: currency },
+          { name: 'robots', content: metaTagRobots || META_ROBOTS },
+          { httpEquiv: 'Content-Type', content: CONTENT_TYPE },
+        ]}
+      />
+      {children}
+    </React.Fragment>
+  )
 }
 
 export default AmpProvider

--- a/react/package.json
+++ b/react/package.json
@@ -3,11 +3,13 @@
   "dependencies": {
     "react": "^16.8.6",
     "react-amphtml": "^4.0.1",
-    "react-dom": "^16.8.6"
+    "react-dom": "^16.8.6",
+    "react-helmet": "^5.2.1"
   },
   "devDependencies": {
     "@types/node": "^12.7.0",
     "@types/react": "^16.8.24",
-    "@types/react-dom": "^16.8.5"
+    "@types/react-dom": "^16.8.5",
+    "@types/react-helmet": "^5.0.9"
   }
 }

--- a/react/typings/vtex.render-runtime.d.ts
+++ b/react/typings/vtex.render-runtime.d.ts
@@ -1,0 +1,3 @@
+declare module 'vtex.render-runtime' {
+  export function useRuntime(): any
+}

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -19,6 +19,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-helmet@^5.0.9":
+  version "5.0.9"
+  resolved "https://registry.yarnpkg.com/@types/react-helmet/-/react-helmet-5.0.9.tgz#60ab5accce74b168ca1d274671522f6b2cf2c98f"
+  integrity sha512-0UVaMQk/Xvq6rFaGyepSBnRApy5RE+YH0XAXlbOBhtez5D9y1/jxKaKODofPzNnJLoLQ+sATTsWQIvrw1Dtiag==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react@*", "@types/react@^16.8.24":
   version "16.8.24"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.24.tgz#8d1ea1fcbfa214220da3d3c04e506f1077b0deac"
@@ -31,6 +38,11 @@ csstype@^2.2.0:
   version "2.6.6"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.6.tgz#c34f8226a94bbb10c32cc0d714afdf942291fc41"
   integrity sha512-RpFbQGUE74iyPgvr46U9t1xoQBM8T4BL8SxrN66Le2xYAPSaDJJKeztV3awugusb3g3G9iL8StmkBBXhcbbXhg==
+
+exenv@^1.2.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/exenv/-/exenv-1.2.2.tgz#2ae78e85d9894158670b03d47bec1f03bd91bb9d"
+  integrity sha1-KueOhdmJQVhnCwPUe+wfA72Ru50=
 
 "js-tokens@^3.0.0 || ^4.0.0":
   version "4.0.0"
@@ -49,7 +61,7 @@ object-assign@^4.1.1:
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
 
-prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.5.4, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -75,10 +87,33 @@ react-dom@^16.8.6:
     prop-types "^15.6.2"
     scheduler "^0.13.6"
 
+react-fast-compare@^2.0.2:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
+  integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
+
+react-helmet@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/react-helmet/-/react-helmet-5.2.1.tgz#16a7192fdd09951f8e0fe22ffccbf9bb3e591ffa"
+  integrity sha512-CnwD822LU8NDBnjCpZ4ySh8L6HYyngViTZLfBBb3NjtrpN8m49clH8hidHouq20I51Y6TpCTISCBbqiY5GamwA==
+  dependencies:
+    object-assign "^4.1.1"
+    prop-types "^15.5.4"
+    react-fast-compare "^2.0.2"
+    react-side-effect "^1.1.0"
+
 react-is@^16.8.1:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
   integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
+
+react-side-effect@^1.1.0:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-1.1.5.tgz#f26059e50ed9c626d91d661b9f3c8bb38cd0ff2d"
+  integrity sha512-Z2ZJE4p/jIfvUpiUMRydEVpQRf2f8GMHczT6qLcARmX7QRb28JDBTpnM2g/i5y/p7ZDEXYGHWg0RbhikE+hJRw==
+  dependencies:
+    exenv "^1.2.1"
+    shallowequal "^1.0.1"
 
 react@^16.8.6:
   version "16.8.6"
@@ -97,3 +132,8 @@ scheduler@^0.13.6:
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
+
+shallowequal@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
+  integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -1,6 +1,8 @@
 {
   "amp-store": {
     "component": "*",
+    "before": ["header.full"],
+    "after": ["footer"],
     "around": ["ampProvider"]
   },
   "amp-store.home": {},


### PR DESCRIPTION
#### What problem is this solving?
Adds the default meta tags that exists in `vtex.store` and adds the `header.full` and `footer` interfaces to the `before` and `after` fields in the `amp-store` interface.

#### How should this be manually tested?

[Workspace](https://lucas--storecomponents.myvtex.com/amp/)

<!-- Your friendly Checklist/Reminders 📝 -->

<!-- 📒 Update `README.md`. -->
<!-- ❕ Update `CHANGELOG.md`. -->
<!-- 🔮 Link this PR to a Clubhouse story (if applicable). -->
<!-- 🤖 Update/create tests (important for bug fixes). -->
<!-- 🚿 Delete the workspace after merging this PR (if applicable). -->

#### Type of changes

<!--- Add a ✔️ where applicable -->

| ✔️  | Type of Change |
| --- | --- |
| \_ | Bug fix <!-- a non-breaking change which fixes an issue --> |
| ✔️ | New feature <!-- a non-breaking change which adds functionality --> |
| \_ | Breaking change <!-- fix or feature that would cause existing functionality to change --> |
| \_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt --> |
