### PR TITLE
Add guards for meta tag content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Add guards for meta tag content attribute.
 
 ## [0.1.0] - 2019-08-08
 ### Added

--- a/react/AmpProvider.tsx
+++ b/react/AmpProvider.tsx
@@ -44,7 +44,7 @@ const AmpProvider: React.FC = ({ children }) => {
           { name: 'currency', content: currency },
           { name: 'robots', content: metaTagRobots || META_ROBOTS },
           { httpEquiv: 'Content-Type', content: CONTENT_TYPE },
-        ]}
+        ].filter(meta => !!meta.content)}
       />
       {children}
     </React.Fragment>


### PR DESCRIPTION
#### What problem is this solving?
We can't have meta tags with empty `content` in AMP pages.

#### How should this be manually tested?

[Workspace](https://lucas--delivery.myvtex.com/amp/)

<!-- Your friendly Checklist/Reminders 📝 -->

<!-- 📒 Update `README.md`. -->
<!-- ❕ Update `CHANGELOG.md`. -->
<!-- 🔮 Link this PR to a Clubhouse story (if applicable). -->
<!-- 🤖 Update/create tests (important for bug fixes). -->
<!-- 🚿 Delete the workspace after merging this PR (if applicable). -->

#### Type of changes

<!--- Add a ✔️ where applicable -->

| ✔️  | Type of Change |
| --- | --- |
| ✔️ | Bug fix <!-- a non-breaking change which fixes an issue --> |
| \_ | New feature <!-- a non-breaking change which adds functionality --> |
| \_ | Breaking change <!-- fix or feature that would cause existing functionality to change --> |
| \_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt --> |