### PR TITLE
Add runtime to AMP state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Runtime config to AMP state.
 
 ## [0.1.2] - 2019-09-04
 

--- a/react/AmpProvider.tsx
+++ b/react/AmpProvider.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Helmet } from 'react-helmet'
 import { useRuntime } from 'vtex.render-runtime'
+import * as Amp from 'react-amphtml'
 
 const CONTENT_TYPE = 'text/html; charset=utf-8'
 const META_ROBOTS = 'index, follow'
@@ -8,11 +9,12 @@ const META_ROBOTS = 'index, follow'
 const joinKeywords = (keywords: string[]) => keywords && keywords.join(', ')
 
 const AmpProvider: React.FC = ({ children }) => {
+  const runtime = useRuntime()
   const {
     getSettings,
     culture: { country, locale, currency },
     route: { title: pageTitle, metaTags },
-  } = useRuntime()
+  } = runtime
 
   const storeSettings = getSettings('vtex.store')
 
@@ -46,6 +48,9 @@ const AmpProvider: React.FC = ({ children }) => {
           { httpEquiv: 'Content-Type', content: CONTENT_TYPE },
         ].filter(meta => !!meta.content)}
       />
+      <Amp.AmpState id="__RUNTIME__" specName="amp-state">
+        {runtime}
+      </Amp.AmpState>
       {children}
     </React.Fragment>
   )


### PR DESCRIPTION
#### What problem is this solving?
Adds the runtime values to AMP state for debugging.

#### How should this be manually tested?

[Workspace](https://lucas--storecomponents.myvtex.com/amp/)

You can check this by accessing the DevTools and running

```javascript
AMP.setLogLevel(4)
AMP.printState()
```

#### Type of changes

<!--- Add a ✔️ where applicable -->

| ✔️  | Type of Change |
| --- | --- |
| \_ | Bug fix <!-- a non-breaking change which fixes an issue --> |
| ✔️ | New feature <!-- a non-breaking change which adds functionality --> |
| \_ | Breaking change <!-- fix or feature that would cause existing functionality to change --> |
| \_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt --> |